### PR TITLE
Added TravisCI build icon (needs activation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/eclipselabs/eclipse-language-service.svg?branch=master)](https://travis-ci.org/eclipselabs/eclipse-language-service)
+
 # Eclipse integration for language service (experiment)
 
 


### PR DESCRIPTION
Note that for the icon to work, an admin for github.com/eclipselabs/eclipse-language-service needs to login to https://travis-ci.org and activate the repository
