### PR TITLE
factorize retrieving document information for contents of text viewer

### DIFF
--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/codeactions/LSPCodeActionMarkerResolution.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/codeactions/LSPCodeActionMarkerResolution.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.ITextFileBufferManager;
 import org.eclipse.core.filebuffers.LocationKind;
 import org.eclipse.core.resources.IFile;
@@ -24,17 +25,20 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.languageserver.LanguageServiceAccessor;
+import org.eclipse.languageserver.LanguageServiceAccessor.LSPDocumentInfo;
 import org.eclipse.languageserver.operations.diagnostics.LSPDiagnosticsToMarkers;
 import org.eclipse.languageserver.ui.Messages;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.IMarkerResolution;
 import org.eclipse.ui.IMarkerResolutionGenerator2;
+import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.views.markers.WorkbenchMarkerResolution;
 
 import io.typefox.lsapi.CodeActionContext;
 import io.typefox.lsapi.CodeActionParams;
 import io.typefox.lsapi.Command;
 import io.typefox.lsapi.Diagnostic;
+import io.typefox.lsapi.ServerCapabilities;
 import io.typefox.lsapi.builders.CodeActionContextBuilder;
 import io.typefox.lsapi.builders.CodeActionParamsBuilder;
 import io.typefox.lsapi.services.transport.client.LanguageClientEndpoint;
@@ -91,8 +95,8 @@ public class LSPCodeActionMarkerResolution extends WorkbenchMarkerResolution imp
 			if (marker.getAttribute(LSP_REMEDIATION) != null) {
 				resolutions = (List<? extends Command>)marker.getAttribute(LSP_REMEDIATION);
 			} else if (marker.getResource().getType() == IResource.FILE) {
-				IDocument document = ITextFileBufferManager.DEFAULT.getTextFileBuffer(marker.getResource().getFullPath(), LocationKind.IFILE).getDocument();
-				LanguageClientEndpoint lsp = LanguageServiceAccessor.getLanguageServer((IFile)marker.getResource(), document);
+				IDocument document = FileBuffers.getTextFileBufferManager().getTextFileBuffer(marker.getResource().getFullPath(), LocationKind.IFILE).getDocument();
+				LanguageClientEndpoint lsp = LanguageServiceAccessor.getLanguageServer((IFile)marker.getResource(), document, null);
 				if (lsp != null) {
 					Diagnostic diagnostic = (Diagnostic)marker.getAttribute(LSPDiagnosticsToMarkers.LSP_DIAGNOSTIC);
 					CodeActionContext context = new CodeActionContextBuilder()

--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/codelens/LSPCodeLensMenu.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/codelens/LSPCodeLensMenu.java
@@ -10,28 +10,20 @@
  *******************************************************************************/
 package org.eclipse.languageserver.operations.codelens;
 
-import java.net.URI;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
-import org.eclipse.core.filebuffers.ITextFileBufferManager;
-import org.eclipse.core.filebuffers.LocationKind;
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.action.ContributionItem;
-import org.eclipse.jface.text.IDocument;
 import org.eclipse.languageserver.LanguageServiceAccessor;
+import org.eclipse.languageserver.LanguageServiceAccessor.LSPDocumentInfo;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
-import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IFileEditorInput;
-import org.eclipse.ui.IURIEditorInput;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.menus.IWorkbenchContribution;
 import org.eclipse.ui.progress.UIJob;
@@ -41,45 +33,27 @@ import org.eclipse.ui.texteditor.ITextEditor;
 import io.typefox.lsapi.CodeLens;
 import io.typefox.lsapi.CodeLensParams;
 import io.typefox.lsapi.builders.CodeLensParamsBuilder;
-import io.typefox.lsapi.services.transport.client.LanguageClientEndpoint;
 
 public class LSPCodeLensMenu extends ContributionItem implements IWorkbenchContribution {
 
-	private LanguageClientEndpoint languageClient;
-	private URI fileUri;
+	private LSPDocumentInfo info;
 
 	@Override
 	public void initialize(IServiceLocator serviceLocator) {
 		IEditorPart editor = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
 		if (editor instanceof ITextEditor) {
-			IEditorInput input = editor.getEditorInput();
-			languageClient = null;
-			fileUri = null;
-			try {
-				IDocument document = null;
-				if (input instanceof IFileEditorInput) { // TODO, also support non resource file
-					IFile file = ((IFileEditorInput) input).getFile();
-					fileUri = file.getLocation().toFile().toURI();
-					document = ITextFileBufferManager.DEFAULT.getTextFileBuffer(file.getFullPath(),	LocationKind.IFILE).getDocument();
-					languageClient = LanguageServiceAccessor.getLanguageServer(file, document);
-				} else if (input instanceof IURIEditorInput) {
-					fileUri = ((IURIEditorInput)input).getURI();
-					document = ITextFileBufferManager.DEFAULT.getTextFileBuffer(new Path(fileUri.getPath()), LocationKind.LOCATION).getDocument();
-					// TODO server
-				}
-			} catch (Exception e) {
-				// TODO: handle exception
-			}
+			info = LanguageServiceAccessor.getLSPDocumentInfoFor((ITextEditor) editor, (capabilities) -> capabilities.getCodeLensProvider() != null );
+			// TODO should be ServerCapabilities::isCodeLensProvider, when available in ls-api
 		}
 	}
-	
+
 	@Override
 	public void fill(final Menu menu, int index) {
 		final MenuItem item = new MenuItem(menu, SWT.NONE, index);
 		item.setText("Computing...");
 		item.setEnabled(false);
-		CodeLensParams param = new CodeLensParamsBuilder().textDocument(fileUri.toString()).build();
-		final CompletableFuture<List<? extends CodeLens>> codeLens = this.languageClient.getTextDocumentService().codeLens(param);
+		CodeLensParams param = new CodeLensParamsBuilder().textDocument(info.fileUri.toString()).build();
+		final CompletableFuture<List<? extends CodeLens>> codeLens = info.languageClient.getTextDocumentService().codeLens(param);
 		codeLens.whenComplete(new BiConsumer<List<? extends CodeLens>, Throwable>() {
 
 			@Override

--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/completion/LSContentAssistProcessor.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/completion/LSContentAssistProcessor.java
@@ -10,13 +10,11 @@
  *******************************************************************************/
 package org.eclipse.languageserver.operations.completion;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
@@ -25,18 +23,12 @@ import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 import org.eclipse.languageserver.LSPEclipseUtils;
 import org.eclipse.languageserver.LanguageServiceAccessor;
-import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IFileEditorInput;
-import org.eclipse.ui.IURIEditorInput;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.texteditor.AbstractTextEditor;
+import org.eclipse.languageserver.LanguageServiceAccessor.LSPDocumentInfo;
 
 import io.typefox.lsapi.CompletionItem;
 import io.typefox.lsapi.CompletionList;
 import io.typefox.lsapi.ServerCapabilities;
 import io.typefox.lsapi.impl.TextDocumentPositionParamsImpl;
-import io.typefox.lsapi.services.transport.client.LanguageClientEndpoint;
 
 public class LSContentAssistProcessor implements IContentAssistProcessor {
 
@@ -46,39 +38,21 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 	@Override
 	public ICompletionProposal[] computeCompletionProposals(ITextViewer viewer, int offset) {
 		ICompletionProposal[] res = new ICompletionProposal[0];
-		IEditorPart activeEditor = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
-		if (!(activeEditor instanceof AbstractTextEditor)) {
-			return new ICompletionProposal[0];
-		}
-		IEditorInput input = activeEditor.getEditorInput();
-		LanguageClientEndpoint languageClient = null;
-		URI fileUri = null;
-		try {
-			if (input instanceof IFileEditorInput) { // TODO, also support non resource file
-				IFile file = ((IFileEditorInput) input).getFile();
-				fileUri = file.getLocation().toFile().toURI();
-				languageClient = LanguageServiceAccessor.getLanguageServer(file, viewer.getDocument(), ServerCapabilities::isCodeActionProvider);
-			} else if (input instanceof IURIEditorInput) {
-				fileUri = ((IURIEditorInput)input).getURI();
-				// TODO server
-			}
-		} catch (Exception ex) {
-			ex.printStackTrace();
-			return res;
-		}
-		
+		final LSPDocumentInfo info = LanguageServiceAccessor.getLSPDocumentInfoFor(viewer, ServerCapabilities::isCodeActionProvider);
 		CompletableFuture<CompletionList> request = null;
 		try {
-			if (languageClient != null) {
+			if (info.languageClient != null) {
 				IDocument document = viewer.getDocument();
-				TextDocumentPositionParamsImpl param = LSPEclipseUtils.toTextDocumentPosistionParams(fileUri, offset, document);
-				request = languageClient.getTextDocumentService().completion(param);
+				TextDocumentPositionParamsImpl param = LSPEclipseUtils.toTextDocumentPosistionParams(info.fileUri, offset, document);
+				request = info.languageClient.getTextDocumentService().completion(param);
 				CompletionList completionList = request.get(5, TimeUnit.SECONDS);
 				res = toProposals(offset, completionList);
 			}
 		} catch (Exception ex) {
 			ex.printStackTrace(); //TODO
-			res = toProposals(offset, request.getNow(null));
+			if (request != null) {
+				res = toProposals(offset, request.getNow(null));
+			}
 		}
 		return res;
 	}

--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/format/LSPFormatHandler.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/format/LSPFormatHandler.java
@@ -10,19 +10,13 @@
  *******************************************************************************/
 package org.eclipse.languageserver.operations.format;
 
-import java.net.URI;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.IHandler;
-import org.eclipse.core.filebuffers.ITextFileBufferManager;
-import org.eclipse.core.filebuffers.LocationKind;
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextSelection;
@@ -30,20 +24,18 @@ import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.languageserver.LSPEclipseUtils;
 import org.eclipse.languageserver.LanguageServiceAccessor;
-import org.eclipse.ui.IEditorInput;
+import org.eclipse.languageserver.LanguageServiceAccessor.LSPDocumentInfo;
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IFileEditorInput;
-import org.eclipse.ui.IURIEditorInput;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
+import org.eclipse.ui.texteditor.ITextEditor;
 
 import io.typefox.lsapi.DocumentFormattingParams;
 import io.typefox.lsapi.ServerCapabilities;
 import io.typefox.lsapi.TextEdit;
 import io.typefox.lsapi.builders.DocumentFormattingParamsBuilder;
-import io.typefox.lsapi.services.transport.client.LanguageClientEndpoint;
 
 public class LSPFormatHandler extends AbstractHandler implements IHandler {
 
@@ -52,79 +44,41 @@ public class LSPFormatHandler extends AbstractHandler implements IHandler {
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		IEditorPart part = HandlerUtil.getActiveEditor(event);
-		if (part instanceof AbstractTextEditor) {
-			IEditorInput input = part.getEditorInput();
-			LanguageClientEndpoint languageClient = null;
-			URI fileUri = null;
-			try {
-				document = null;
-				if (input instanceof IFileEditorInput) { // TODO, also support non resource file
-					IFile file = ((IFileEditorInput) input).getFile();
-					fileUri = file.getLocation().toFile().toURI();
-					document = ITextFileBufferManager.DEFAULT.getTextFileBuffer(file.getFullPath(),	LocationKind.IFILE).getDocument();
-					languageClient = LanguageServiceAccessor.getLanguageServer(file, document, ServerCapabilities::isDocumentFormattingProvider);
-				} else if (input instanceof IURIEditorInput) {
-					fileUri = ((IURIEditorInput)input).getURI();
-					document = ITextFileBufferManager.DEFAULT.getTextFileBuffer(new Path(fileUri.getPath()), LocationKind.LOCATION).getDocument();
-					// TODO server
-				}
-		
-				if (languageClient != null) {
-					ISelection sel = ((AbstractTextEditor) part).getSelectionProvider().getSelection();
-					if (sel instanceof TextSelection) {
-						DocumentFormattingParams params = new DocumentFormattingParamsBuilder()
-								.textDocument(fileUri.toString())
-								.build();
-					    CompletableFuture<List<? extends TextEdit>> rename = languageClient.getTextDocumentService().formatting(params);
-					    rename.thenAccept(new Consumer<List<? extends TextEdit>>() {
-							@Override
-							public void accept(List<? extends TextEdit> t) {
-								for (TextEdit textEdit : t) {
-									try {
-										document.replace(
-												LSPEclipseUtils.toOffset(textEdit.getRange().getStart(), document),
-												LSPEclipseUtils.toOffset(textEdit.getRange().getEnd(), document) - LSPEclipseUtils.toOffset(textEdit.getRange().getStart(), document),
-												textEdit.getNewText());
-									} catch (BadLocationException e) {
-										// TODO Auto-generated catch block
-										e.printStackTrace();
-									}
-								}
+		if (part instanceof ITextEditor) {
+			LSPDocumentInfo info = LanguageServiceAccessor.getLSPDocumentInfoFor((ITextEditor) part, ServerCapabilities::isDocumentFormattingProvider);
+			if (info.languageClient != null) {
+				ISelection sel = ((AbstractTextEditor) part).getSelectionProvider().getSelection();
+				if (sel instanceof TextSelection) {
+					DocumentFormattingParams params = new DocumentFormattingParamsBuilder()
+							.textDocument(info.fileUri.toString())
+							.build();
+					CompletableFuture<List<? extends TextEdit>> formatter = info.languageClient.getTextDocumentService().formatting(params);
+					formatter.thenAccept((List<? extends TextEdit> t) -> {
+						for (TextEdit textEdit : t) {
+							try {
+								document.replace(
+										LSPEclipseUtils.toOffset(textEdit.getRange().getStart(), document),
+										LSPEclipseUtils.toOffset(textEdit.getRange().getEnd(), document) - LSPEclipseUtils.toOffset(textEdit.getRange().getStart(), document),
+										textEdit.getNewText());
+							} catch (BadLocationException e) {
+								// TODO Auto-generated catch block
+								e.printStackTrace();
 							}
-						});
-					}
+						}
+					});
 				}
-			} catch (Exception ex) {
-				
 			}
 		}
 		return null;
 	}
-	
+
 	@Override
 	public boolean isEnabled() {
 		IWorkbenchPart part = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActivePart();
-		if (part instanceof AbstractTextEditor) {
-			IEditorInput input = ((AbstractTextEditor)part).getEditorInput();
-			LanguageClientEndpoint languageClient = null;
-			URI fileUri = null;
-			try {
-				IDocument document = null;
-				if (input instanceof IFileEditorInput) { // TODO, also support non resource file
-					IFile file = ((IFileEditorInput) input).getFile();
-					fileUri = file.getLocation().toFile().toURI();
-					document = ITextFileBufferManager.DEFAULT.getTextFileBuffer(file.getFullPath(),	LocationKind.IFILE).getDocument();
-					languageClient = LanguageServiceAccessor.getLanguageServer(file, document, ServerCapabilities::isDocumentFormattingProvider);
-				} else if (input instanceof IURIEditorInput) {
-					fileUri = ((IURIEditorInput)input).getURI();
-					document = ITextFileBufferManager.DEFAULT.getTextFileBuffer(new Path(fileUri.getPath()), LocationKind.LOCATION).getDocument();
-					// TODO server
-				}
-				ISelection selection = ((AbstractTextEditor)part).getSelectionProvider().getSelection();
-				return languageClient != null && !selection.isEmpty() && selection instanceof ITextSelection;
-			} catch (Exception ex) {
-				return false;
-			}
+		if (part instanceof ITextEditor) {
+			LSPDocumentInfo info = LanguageServiceAccessor.getLSPDocumentInfoFor((ITextEditor) part, ServerCapabilities::isDocumentFormattingProvider);
+			ISelection selection = ((ITextEditor) part).getSelectionProvider().getSelection();
+			return info.languageClient != null && !selection.isEmpty() && selection instanceof ITextSelection;
 		}
 		return false;
 	}


### PR DESCRIPTION
Several operations need to detect information on the file in a text viewer. The required magical incantations are extracted to a helper method. If it looks ok, I can let the operations use this method.

I'm not sure if LSPDocumentInfo should be a standalone class?

BTW, I suppose even the completion processor should use this (instead of going for the currently active editor)?
