### PR TITLE
Add --stdio for the 3 launches to support JSON, CSS server without hack

### DIFF
--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/languages/InitializeLaunchConfigurations.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/languages/InitializeLaunchConfigurations.java
@@ -98,6 +98,7 @@ public class InitializeLaunchConfigurations implements IStartup {
 				//     (don't forget the `npm run watch` after the install script)
 				// 3. Then set language server location and adapt process builder.
 				workingCopy.setAttribute(IExternalToolConstants.ATTR_LOCATION, "/usr/bin/node");
+				// Arguments are: CSS server & --stdio to support stdin/stdout on server side because launch can work only with stdio transport (not with IPC transport)
 				workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "/home/mistria/git/vscode/extensions/css/server/out/cssServerMain.js --stdio");
 				omniSharpLauch = workingCopy.doSave();
 				registry.registerAssociation(contentTypeManager.getContentType("org.eclipse.wst.css.core.csssource"), LaunchConfigurationStreamProvider.findLaunchConfiguration(IExternalToolConstants.ID_PROGRAM_LAUNCH_CONFIGURATION_TYPE, InitializeLaunchConfigurations.VSCODE_CSS_NAME));
@@ -130,6 +131,7 @@ public class InitializeLaunchConfigurations implements IStartup {
 				//     (don't forget the `npm run watch` after the install script)
 				// 3. Then set language server location and adapt process builder.
 				workingCopy.setAttribute(IExternalToolConstants.ATTR_LOCATION, "/usr/bin/node");
+				// Arguments are: JSON server & --stdio to support stdin/stdout on server side because launch can work only with stdio transport (not with IPC transport)
 				workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "/home/mistria/git/vscode/extensions/json/server/out/jsonServerMain.js --stdio");
 				omniSharpLauch = workingCopy.doSave();
 				registry.registerAssociation(contentTypeManager.getContentType("org.eclipse.wst.jsdt.core.jsonSource"), LaunchConfigurationStreamProvider.findLaunchConfiguration(IExternalToolConstants.ID_PROGRAM_LAUNCH_CONFIGURATION_TYPE, InitializeLaunchConfigurations.VSCODE_JSON_NAME));

--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/languages/InitializeLaunchConfigurations.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/languages/InitializeLaunchConfigurations.java
@@ -62,7 +62,7 @@ public class InitializeLaunchConfigurations implements IStartup {
 				workingCopy.setAttribute(IExternalToolConstants.ATTR_BUILD_SCOPE, "${none}");
 				workingCopy.setAttribute(DebugPlugin.ATTR_CAPTURE_OUTPUT, true);
 				workingCopy.setAttribute(IExternalToolConstants.ATTR_LOCATION, "/usr/bin/node");
-				workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "/home/mistria/git/omnisharp-node-client/languageserver/server.js");
+				workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "/home/mistria/git/omnisharp-node-client/languageserver/server.js --stdio");
 				workingCopy.setAttribute(ILaunchManager.ATTR_APPEND_ENVIRONMENT_VARIABLES, true);
 				Map<String, String> environment = new HashMap<>(1);
 				environment.put("LD_LIBRARY_PATH", "/home/mistria/apps/OmniSharp.NET/icu54:" + System.getenv("LD_LIBRARY_PATH"));
@@ -98,7 +98,7 @@ public class InitializeLaunchConfigurations implements IStartup {
 				//     (don't forget the `npm run watch` after the install script)
 				// 3. Then set language server location and adapt process builder.
 				workingCopy.setAttribute(IExternalToolConstants.ATTR_LOCATION, "/usr/bin/node");
-				workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "/home/mistria/git/vscode/extensions/css/server/out/cssServerMain.js");
+				workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "/home/mistria/git/vscode/extensions/css/server/out/cssServerMain.js --stdio");
 				omniSharpLauch = workingCopy.doSave();
 				registry.registerAssociation(contentTypeManager.getContentType("org.eclipse.wst.css.core.csssource"), LaunchConfigurationStreamProvider.findLaunchConfiguration(IExternalToolConstants.ID_PROGRAM_LAUNCH_CONFIGURATION_TYPE, InitializeLaunchConfigurations.VSCODE_CSS_NAME));
 			}
@@ -130,7 +130,7 @@ public class InitializeLaunchConfigurations implements IStartup {
 				//     (don't forget the `npm run watch` after the install script)
 				// 3. Then set language server location and adapt process builder.
 				workingCopy.setAttribute(IExternalToolConstants.ATTR_LOCATION, "/usr/bin/node");
-				workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "/home/mistria/git/vscode/extensions/json/server/out/jsonServerMain.js");
+				workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "/home/mistria/git/vscode/extensions/json/server/out/jsonServerMain.js --stdio");
 				omniSharpLauch = workingCopy.doSave();
 				registry.registerAssociation(contentTypeManager.getContentType("org.eclipse.wst.jsdt.core.jsonSource"), LaunchConfigurationStreamProvider.findLaunchConfiguration(IExternalToolConstants.ID_PROGRAM_LAUNCH_CONFIGURATION_TYPE, InitializeLaunchConfigurations.VSCODE_JSON_NAME));
 			}

--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/languages/InitializeLaunchConfigurations.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/languages/InitializeLaunchConfigurations.java
@@ -62,7 +62,7 @@ public class InitializeLaunchConfigurations implements IStartup {
 				workingCopy.setAttribute(IExternalToolConstants.ATTR_BUILD_SCOPE, "${none}");
 				workingCopy.setAttribute(DebugPlugin.ATTR_CAPTURE_OUTPUT, true);
 				workingCopy.setAttribute(IExternalToolConstants.ATTR_LOCATION, "/usr/bin/node");
-				workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "/home/mistria/git/omnisharp-node-client/languageserver/server.js --stdio");
+				workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "/home/mistria/git/omnisharp-node-client/languageserver/server.js");
 				workingCopy.setAttribute(ILaunchManager.ATTR_APPEND_ENVIRONMENT_VARIABLES, true);
 				Map<String, String> environment = new HashMap<>(1);
 				environment.put("LD_LIBRARY_PATH", "/home/mistria/apps/OmniSharp.NET/icu54:" + System.getenv("LD_LIBRARY_PATH"));


### PR DESCRIPTION
This PR gives the capability to consumes JSON, CSS server with Eclipse launch without hacking it. See https://github.com/eclipselabs/eclipse-language-service/issues/28#issuecomment-250414370
