### PR TITLE
Check ServerCapabilities#getCompletionProvider for completion

### DIFF
--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/completion/LSContentAssistProcessor.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/completion/LSContentAssistProcessor.java
@@ -37,7 +37,7 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 	@Override
 	public ICompletionProposal[] computeCompletionProposals(ITextViewer viewer, int offset) {
 		ICompletionProposal[] res = new ICompletionProposal[0];
-		final LSPDocumentInfo info = LanguageServiceAccessor.getLSPDocumentInfoFor(viewer, capabilities -> capabilities.getCodeLensProvider() != null);
+		final LSPDocumentInfo info = LanguageServiceAccessor.getLSPDocumentInfoFor(viewer, capabilities -> capabilities.getCompletionProvider() != null);
 		CompletableFuture<CompletionList> request = null;
 		try {
 			if (info.languageClient != null) {


### PR DESCRIPTION
Check ServerCapabilities#getCompletionProvider for completion. In my case it fixes a bug with CSS completion which starts every time a new VSCode-CSS launch as soon as I open completion.
