### PR TITLE
Avoid NPE for null keys in registry

### DIFF
--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/LSPStreamConnectionProviderRegistry.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/LSPStreamConnectionProviderRegistry.java
@@ -106,7 +106,7 @@ public class LSPStreamConnectionProviderRegistry {
 	public List<StreamConnectionProvider> findProviderFor(final IContentType contentType) {
 		return Arrays.asList(connections
 			.stream()
-			.filter(entry -> { return entry.getKey().equals(contentType); })
+			.filter(entry -> { return entry.getKey() != null && entry.getKey().equals(contentType); })
 			.map(entry -> { return new LaunchConfigurationStreamProvider(entry.getValue()); })
 			.toArray(StreamConnectionProvider[]::new));
 	}


### PR DESCRIPTION
Reason for this:

java.lang.NullPointerException
    at org.eclipse.languageserver.LSPStreamConnectionProviderRegistry.lambda$0(LSPStreamConnectionProviderRegistry.java:109)
    at java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
    at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)
    at java.util.stream.AbstractPipeline.copyInto(Unknown Source)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
    at java.util.stream.AbstractPipeline.evaluate(Unknown Source)
    at java.util.stream.AbstractPipeline.evaluateToArrayNode(Unknown Source)
    at java.util.stream.ReferencePipeline.toArray(Unknown Source)
    at org.eclipse.languageserver.LSPStreamConnectionProviderRegistry.findProviderFor(LSPStreamConnectionProviderRegistry.java:111)
    at org.eclipse.languageserver.LanguageServiceAccessor.getLSWrapper(LanguageServiceAccessor.java:206)
    at org.eclipse.languageserver.LanguageServiceAccessor.getLanguageServer(LanguageServiceAccessor.java:170)
    at org.eclipse.languageserver.LanguageServiceAccessor.getLSPDocumentInfoFor(LanguageServiceAccessor.java:133)
    at org.eclipse.languageserver.operations.hover.LSBasedHover.getHoverRegion(LSBasedHover.java:60)
    at org.eclipse.jface.text.TextViewerHoverManager.computeInformation(TextViewerHoverManager.java:138)
    at org.eclipse.jface.text.AbstractInformationControlManager.doShowInformation(AbstractInformationControlManager.java:1144)
    at org.eclipse.jface.text.AbstractHoverInformationControlManager$MouseTracker.mouseHover(AbstractHoverInformationControlManager.java:518)
    at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:209)
    at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:84)
    at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4410)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1079)
    at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4228)
    at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3816)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1121)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1022)
    at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:150)
    at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:687)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
    at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:604)
    at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:148)
    at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:138)
    at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:388)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:243)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:673)
    at org.eclipse.equinox.launcher.Main.basicRun(Main.java:610)
    at org.eclipse.equinox.launcher.Main.run(Main.java:1519)
