### PR TITLE
Support for symbols in workspace

### DIFF
--- a/org.eclipse.languageserver/plugin.xml
+++ b/org.eclipse.languageserver/plugin.xml
@@ -38,6 +38,10 @@
             id="org.eclipse.languageserver.symbolinfile"
             name="Go to Symbol in File">
       </command>
+      <command
+            id="org.eclipse.languageserver.symbolinworkspace"
+            name="Go to Symbol in Workspace">
+      </command>
    </extension>
    <extension
          point="org.eclipse.ui.handlers">
@@ -86,6 +90,10 @@
       <handler
             class="org.eclipse.languageserver.operations.symbols.LSPSymbolInFileHandler"
             commandId="org.eclipse.languageserver.symbolinfile">
+      </handler>
+      <handler
+            class="org.eclipse.languageserver.operations.symbols.LSPSymbolInWorkspaceHandler"
+            commandId="org.eclipse.languageserver.symbolinworkspace">
       </handler>
    </extension>
    <extension
@@ -160,6 +168,12 @@
             contextId="org.eclipse.ui.textEditorScope"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M1+M2+O">
+      </key>
+      <key
+            commandId="org.eclipse.languageserver.symbolinworkspace"
+            contextId="org.eclipse.ui.contexts.window"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+T">
       </key>
    </extension>
    <extension

--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/symbols/LSPSymbolInWorkspaceDialog.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/symbols/LSPSymbolInWorkspaceDialog.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Rogue Wave Software Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Michał Niewrzał (Rogue Wave Software Inc.) - initial implementation
+ *******************************************************************************/
+package org.eclipse.languageserver.operations.symbols;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.dialogs.IDialogSettings;
+import org.eclipse.jface.text.contentassist.BoldStylerProvider;
+import org.eclipse.jface.viewers.StyledString;
+import org.eclipse.languageserver.LanguageServerPluginActivator;
+import org.eclipse.languageserver.LanguageServiceAccessor.LSPServerInfo;
+import org.eclipse.languageserver.outline.SymbolsLabelProvider;
+import org.eclipse.languageserver.ui.Messages;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.dialogs.FilteredItemsSelectionDialog;
+
+import io.typefox.lsapi.SymbolInformation;
+import io.typefox.lsapi.WorkspaceSymbolParams;
+import io.typefox.lsapi.builders.WorkspaceSymbolParamsBuilder;
+
+public class LSPSymbolInWorkspaceDialog extends FilteredItemsSelectionDialog {
+
+	private static final String DIALOG_SETTINGS = LSPSymbolInWorkspaceDialog.class.getName();
+
+	private static class InternalSymbolsLabelProvider extends SymbolsLabelProvider {
+
+		private String pattern;
+		private BoldStylerProvider stylerProvider;
+
+		public InternalSymbolsLabelProvider(BoldStylerProvider stylerProvider) {
+			super(true);
+			this.stylerProvider = stylerProvider;
+		}
+
+		@Override
+		public StyledString getStyledText(Object element) {
+			StyledString styledString = super.getStyledText(element);
+			int index = styledString.getString().toLowerCase().indexOf(pattern);
+			if (index != -1) {
+				styledString.setStyle(index, pattern.length(), stylerProvider.getBoldStyler());
+			}
+			return styledString;
+		}
+
+		public void setPattern(String pattern) {
+			this.pattern = pattern;
+		}
+	}
+
+	private class InternalItemsFilter extends ItemsFilter {
+
+		@Override
+		public boolean matchItem(Object item) {
+			if (!(item instanceof SymbolInformation)) {
+				return false;
+			}
+			SymbolInformation info = (SymbolInformation) item;
+			return info.getName().toLowerCase().indexOf(getPattern().toLowerCase()) != -1;
+		}
+
+		@Override
+		public boolean isConsistentItem(Object item) {
+			return true;
+		}
+	}
+
+	private List<LSPServerInfo> infos;
+	private InternalSymbolsLabelProvider labelProvider;
+
+	public LSPSymbolInWorkspaceDialog(Shell shell, List<LSPServerInfo> infos) {
+		super(shell);
+		this.infos = infos;
+		this.labelProvider = new InternalSymbolsLabelProvider(new BoldStylerProvider(shell.getFont()));
+		setMessage(Messages.LSPSymbolInWorkspaceDialog_DialogLabel);
+		setTitle(Messages.LSPSymbolInWorkspaceDialog_DialogTitle);
+		setListLabelProvider(labelProvider);
+	}
+
+	@Override
+	protected ItemsFilter createFilter() {
+		InternalItemsFilter itemsFilter = new InternalItemsFilter();
+		labelProvider.setPattern(itemsFilter.getPattern());
+		return itemsFilter;
+	}
+
+	@Override
+	protected void fillContentProvider(AbstractContentProvider contentProvider, ItemsFilter itemsFilter,
+	        IProgressMonitor monitor) throws CoreException {
+		if (itemsFilter.getPattern().isEmpty()) {
+			return;
+		}
+
+		for (LSPServerInfo info : infos) {
+			if (monitor.isCanceled()) {
+				return;
+			}
+
+			WorkspaceSymbolParams params = new WorkspaceSymbolParamsBuilder().query(itemsFilter.getPattern()).build();
+			CompletableFuture<List<? extends SymbolInformation>> symbols = info.getLanguageClient()
+			        .getWorkspaceService().symbol(params);
+
+			try {
+				List<?> items = symbols.get(1, TimeUnit.SECONDS);
+				for (Object item : items) {
+					if (item != null) {
+						contentProvider.add(item, itemsFilter);
+					}
+				}
+			} catch (InterruptedException | ExecutionException | TimeoutException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+	}
+
+	@Override
+	public String getElementName(Object item) {
+		SymbolInformation info = (SymbolInformation) item;
+		return info.getName();
+	}
+
+	@Override
+	protected Comparator<SymbolInformation> getItemsComparator() {
+		return new Comparator<SymbolInformation>() {
+
+			@Override
+			public int compare(SymbolInformation o1, SymbolInformation o2) {
+				return o1.getName().compareToIgnoreCase(o2.getName());
+			}
+		};
+	}
+
+	@Override
+	protected IStatus validateItem(Object item) {
+		return Status.OK_STATUS;
+	}
+
+	@Override
+	protected IDialogSettings getDialogSettings() {
+		IDialogSettings settings = LanguageServerPluginActivator.getDefault().getDialogSettings()
+		        .getSection(DIALOG_SETTINGS);
+		if (settings == null) {
+			settings = LanguageServerPluginActivator.getDefault().getDialogSettings().addNewSection(DIALOG_SETTINGS);
+		}
+		return settings;
+	}
+
+	@Override
+	protected Control createExtendedContentArea(Composite parent) {
+		return null;
+	}
+
+}

--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/symbols/LSPSymbolInWorkspaceHandler.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/operations/symbols/LSPSymbolInWorkspaceHandler.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Rogue Wave Software Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Michał Niewrzał (Rogue Wave Software Inc.) - initial implementation
+ *******************************************************************************/
+package org.eclipse.languageserver.operations.symbols;
+
+import java.util.List;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.languageserver.LSPEclipseUtils;
+import org.eclipse.languageserver.LanguageServiceAccessor;
+import org.eclipse.languageserver.LanguageServiceAccessor.LSPServerInfo;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+import io.typefox.lsapi.Location;
+import io.typefox.lsapi.ServerCapabilities;
+import io.typefox.lsapi.SymbolInformation;
+
+public class LSPSymbolInWorkspaceHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		IEditorPart part = HandlerUtil.getActiveEditor(event);
+		IResource resource = null;
+		if (part != null && part.getEditorInput() != null) {
+			resource = part.getEditorInput().getAdapter(IResource.class);
+		} else {
+			IStructuredSelection selection = HandlerUtil.getCurrentStructuredSelection(event);
+			if (selection.isEmpty() || !(selection.getFirstElement() instanceof IAdaptable)) {
+				return null;
+			}
+			IAdaptable adaptable = (IAdaptable) selection.getFirstElement();
+			resource = adaptable.getAdapter(IResource.class);
+		}
+
+		if (resource == null) {
+			return null;
+		}
+		IProject project = resource.getProject();
+		List<LSPServerInfo> infos = LanguageServiceAccessor.getLSPServerInfos(project,
+		        ServerCapabilities::isWorkspaceSymbolProvider);
+		if (infos.isEmpty()) {
+			return null;
+		}
+		final Shell shell = HandlerUtil.getActiveShell(event);
+		LSPSymbolInWorkspaceDialog dialog = new LSPSymbolInWorkspaceDialog(shell, infos);
+		if (dialog.open() != IDialogConstants.OK_ID) {
+			return null;
+		}
+		SymbolInformation symbolInformation = (SymbolInformation) dialog.getFirstResult();
+		Location location = symbolInformation.getLocation();
+
+		IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+		LSPEclipseUtils.openInEditor(location, page);
+		return null;
+	}
+
+}

--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/outline/SymbolsLabelProvider.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/outline/SymbolsLabelProvider.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.languageserver.outline;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,8 +43,21 @@ public class SymbolsLabelProvider extends LabelProvider implements ICommonLabelP
 
 	private Map<Image, Image[]> overlays = new HashMap<>();
 	
+	private boolean showLocation;
+
+	public SymbolsLabelProvider() {
+		this(false);
+	}
+
+	public SymbolsLabelProvider(boolean showLocation) {
+		this.showLocation = showLocation;
+	}
+	
 	@Override
 	public Image getImage(Object element) {
+		if (element == null){
+			return null;
+		}
 		if (element == LSSymbolsContentProvider.COMPUTING) {
 			return JFaceResources.getImage(ProgressManager.WAITING_JOB_KEY);
 		}
@@ -108,6 +122,7 @@ public class SymbolsLabelProvider extends LabelProvider implements ICommonLabelP
 
 	@Override
 	public StyledString getStyledText(Object element) {
+
 		if (element == LSSymbolsContentProvider.COMPUTING) {
 			return new StyledString(Messages.outline_computingSymbols);
 		}
@@ -117,11 +132,20 @@ public class SymbolsLabelProvider extends LabelProvider implements ICommonLabelP
 		if (element instanceof LSPDocumentInfo) {
 			return new StyledString(((LSPDocumentInfo)element).getFileUri().getPath());
 		}
-		SymbolInformation symbol = (SymbolInformation) element;
 		StyledString res = new StyledString();
+		if (element == null){
+			return res;
+		}
+		SymbolInformation symbol = (SymbolInformation) element;
 		res.append(symbol.getName(), null);
 		res.append(" :", null); //$NON-NLS-1$
 		res.append(symbol.getKind().toString(), StyledString.DECORATIONS_STYLER);
+
+		if (showLocation) {
+			URI uri = URI.create(symbol.getLocation().getUri());
+			res.append(' ');
+			res.append(uri.getPath(), StyledString.QUALIFIER_STYLER);
+		}
 		return res;
 	}
 

--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/ui/Messages.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/ui/Messages.java
@@ -30,6 +30,8 @@ public class Messages extends NLS {
 	public static String rename_job;
 	public static String referenceSearchQuery;
 	public static String computing;
+	public static String LSPSymbolInWorkspaceDialog_DialogLabel;
+	public static String LSPSymbolInWorkspaceDialog_DialogTitle;
 	public static String updateCodelensMenu_job;
 	public static String outline_computingSymbols;
 

--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/ui/messages.properties
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/ui/messages.properties
@@ -28,5 +28,7 @@ initializeLanguageServer_job=Initialize language server
 rename_job=Rename
 referenceSearchQuery=References
 computing=Computing...
+LSPSymbolInWorkspaceDialog_DialogLabel=Select an item to open.
+LSPSymbolInWorkspaceDialog_DialogTitle=Open Symbol in Workspace
 updateCodelensMenu_job=Update ColeLens menu
 outline_computingSymbols=Computing symbols...


### PR DESCRIPTION
This implementation brings dialog to search and open symbol from workspace. Method 'workspace/symbol' is used to query active servers that are attached to given project. 