### PR TITLE
Support for 'window/showMessage'

### DIFF
--- a/org.eclipse.languageserver/META-INF/MANIFEST.MF
+++ b/org.eclipse.languageserver/META-INF/MANIFEST.MF
@@ -30,7 +30,9 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.swt,
  com.google.gson;bundle-version="2.5.0",
  org.eclipse.jdt.annotation;bundle-version="2.1.0";resolution:=optional,
- org.eclipse.ui.navigator;bundle-version="3.6.100"
+ org.eclipse.ui.navigator;bundle-version="3.6.100",
+ org.eclipse.mylyn.commons.notifications.core,
+ org.eclipse.mylyn.commons.notifications.ui
 Bundle-ClassPath: .
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.languageserver/plugin.properties
+++ b/org.eclipse.languageserver/plugin.properties
@@ -16,3 +16,5 @@ refactorings.menu.label=Refactorings
 codelens.menu.label=Code Lens
 codeactions.menu.label=Code Actions
 languageservers.preference.page=Language Servers
+notification.category.label = LSP
+notification.event.label = LSP Notification

--- a/org.eclipse.languageserver/plugin.xml
+++ b/org.eclipse.languageserver/plugin.xml
@@ -205,5 +205,21 @@
          </includes>
       </viewerContentBinding>
    </extension>
+   <extension
+         point="org.eclipse.mylyn.commons.notifications.ui.notifications">
+        <category
+        	id="org.eclipse.languageserver"
+        	label="%notification.category.label">
+        </category>
+		<event
+		    categoryId="org.eclipse.languageserver"
+		    id="lsp.notification"
+		    label="%notification.event.label"
+		    selected="true">
+		    <defaultHandler
+		      sinkId="org.eclipse.mylyn.commons.notifications.sink.Popup">
+		    </defaultHandler>
+		</event>
+   </extension>
 
 </plugin>

--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/ProjectSpecificLanguageServerWrapper.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/ProjectSpecificLanguageServerWrapper.java
@@ -230,6 +230,11 @@ public class ProjectSpecificLanguageServerWrapper {
 			ConcurrentMessageReader multiThreadReader = new ConcurrentMessageReader(baseMessageReader, executorService);
 			MessageWriter writer = new StreamMessageWriter(this.lspStreamProvider.getOutputStream(), jsonHandler);
 			languageClient.connect(multiThreadReader, writer);
+			
+			languageClient.getWindowService().onLogMessage(params -> ServerMessageHandler.logMessage(params));
+			languageClient.getWindowService().onShowMessage(params -> ServerMessageHandler.showMessage(params));
+			languageClient.getWindowService().onShowMessageRequest(params -> ServerMessageHandler.showMessageRequest(params));
+			
 			this.initializeJob = new Job(Messages.initializeLanguageServer_job) {
 				protected IStatus run(IProgressMonitor monitor) {
 					InitializeParamsImpl initParams = new InitializeParamsImpl();

--- a/org.eclipse.languageserver/src/org/eclipse/languageserver/ServerMessageHandler.java
+++ b/org.eclipse.languageserver/src/org/eclipse/languageserver/ServerMessageHandler.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Rogue Wave Software Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Michał Niewrzał (Rogue Wave Software Inc.) - initial implementation
+ *******************************************************************************/
+package org.eclipse.languageserver;
+
+import java.util.Collections;
+import java.util.Date;
+
+import org.eclipse.mylyn.commons.notifications.core.AbstractNotification;
+import org.eclipse.mylyn.commons.notifications.ui.NotificationsUi;
+
+import io.typefox.lsapi.MessageParams;
+import io.typefox.lsapi.ShowMessageRequestParams;
+
+@SuppressWarnings("restriction")
+public class ServerMessageHandler {
+
+	private static class LSPNotification extends AbstractNotification {
+
+		private String label;
+		private String description;
+
+		public LSPNotification(String label, String description) {
+			super("lsp.notification"); //$NON-NLS-1$
+			this.label = label;
+			this.description = description;
+		}
+
+		@Override
+		public String getLabel() {
+			return label;
+		}
+
+		@Override
+		public String getDescription() {
+			return description;
+		}
+
+		@Override
+		public Date getDate() {
+			return new Date();
+		}
+
+		@Override
+		public <T> T getAdapter(Class<T> adapter) {
+			return null;
+		}
+
+	}
+
+	public static void logMessage(MessageParams params) {
+		// TODO 
+	}
+
+	public static void showMessage(MessageParams params) {
+		AbstractNotification notification = new LSPNotification(String.format("LSP (%s)", params.getType()), //$NON-NLS-1$
+		        params.getMessage());
+		NotificationsUi.getService().notify(Collections.singletonList(notification));
+	}
+
+	public static void showMessageRequest(ShowMessageRequestParams params) {
+		// TODO 
+	}
+
+}


### PR DESCRIPTION
Mylyn notifications are used to show messages sent with 'window/showMessage' request.